### PR TITLE
added checks for invalid twilio config and better error handling

### DIFF
--- a/tabletop/__init__.py
+++ b/tabletop/__init__.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import subqueryload
 import phonenumbers
 from phonenumbers import PhoneNumberFormat
 
+from twilio import TwilioRestException
 from twilio.rest import TwilioRestClient
 
 from uber.common import *

--- a/tabletop/utils.py
+++ b/tabletop/utils.py
@@ -1,7 +1,11 @@
 from tabletop import *
 
 # TODO: automatically merge [secret] plugin config with secret config options in global c object
-client = TwilioRestClient(tabletop_config['secret']['twilio_sid'], tabletop_config['secret']['twilio_token'])
+try:
+    client = TwilioRestClient(tabletop_config['secret']['twilio_sid'], tabletop_config['secret']['twilio_token'])
+except:
+    log.error('unable to initialize twilio rest client; you probably need to set the sid / token', exc_info=True)
+    client = None
 
 
 def normalize(phone_number):
@@ -10,7 +14,9 @@ def normalize(phone_number):
 
 def send_sms(to, body, from_=c.TWILIO_NUMBER):
     to = normalize(to)
-    if not c.DEV_BOX or to in c.TEST_NUMBERS:
-        return client.messages.create(to=to, body=body, from_=normalize(from_))
-    else:
+    if not client:
+        log.error('no twilio client configured')
+    elif c.DEV_BOX and to not in c.TEST_NUMBERS:
         log.info('We are in dev box mode, so we are not sending {!r} to {!r}', body, to)
+    else:
+        return client.messages.create(to=to, body=body, from_=normalize(from_))


### PR DESCRIPTION
Two main things fixed here:

1) If we left the twilio creds blank, the system would fail to start.  Now we just disable the SMS functionality and log a warning.

2) Previously if someone entered an invalid cellphone number, we'd try to re-send every minute.  Now we just mark it as sent with an error so as to not retry.