### PR TITLE
optimize: move angular dynamically genereated javascript out of static_views

### DIFF
--- a/tabletop/templates/tabletop_checkins/index.html
+++ b/tabletop/templates/tabletop_checkins/index.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="../static/deps/combined.css" />
     <link rel="stylesheet" type="text/css" href="../static/styles/styles.css" />
     <script src="../static/deps/combined.js"></script>
-    <script src="../static_views/magfest.js"></script>
+    <script src="../angular/magfest.js"></script>
     <script src="../static/angular-apps/tabletop_checkins/app.js"></script>
     <script>
         var GAMES = {{ games|jsonize }};          // Game service checks for this global variable to get preloaded data

--- a/tabletop/templates/tabletop_tournaments/index.html
+++ b/tabletop/templates/tabletop_tournaments/index.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="../static/deps/combined.css" />
     <link rel="stylesheet" type="text/css" href="../static/styles/styles.css" />
     <script src="../static/deps/combined.js"></script>
-    <script src="../static_views/magfest.js"></script>
+    <script src="../angular/magfest.js"></script>
     <script src="../static/angular-apps/tabletop_tournaments/app.js"></script>
     <script>
         // Tournaments service checks for this global variable to avoid needing to make an initial Ajax request


### PR DESCRIPTION
- this is to make it so we can more aggressively cache static_views
- magfest.js is the only potentially dynamic file that likely we shouldn't cache

merge after https://github.com/magfest/ubersystem/issues/1973