### PR TITLE
Remove phonenumbers dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 twilio==5.2.0
-phonenumbers==7.2.3


### PR DESCRIPTION
If magfest/ubersystem#2858 is accepted, then this dependency will be present in ubersystem, so we don't need it here.